### PR TITLE
Migrate settings to Obsidian 1.13 API

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint-plugin-jsdoc": "48.0.2",
     "eslint-plugin-prefer-arrow": "1.2.3",
     "eslint-plugin-simple-import-sort": "10.0.0",
-    "obsidian": "https://github.com/obsidianmd/obsidian-api/archive/df9434bec6883bd32727f61b1ed1336f7663d0e4.tar.gz",
+    "obsidian": "^1.13.1",
     "tslib": "2.6.2",
     "typescript": "5.3.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ importers:
         specifier: 10.0.0
         version: 10.0.0(eslint@8.57.1)
       obsidian:
-        specifier: https://github.com/obsidianmd/obsidian-api/archive/df9434bec6883bd32727f61b1ed1336f7663d0e4.tar.gz
-        version: https://github.com/obsidianmd/obsidian-api/archive/df9434bec6883bd32727f61b1ed1336f7663d0e4.tar.gz(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+        specifier: ^1.13.1
+        version: 1.13.1(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
       tslib:
         specifier: 2.6.2
         version: 2.6.2
@@ -823,12 +823,11 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  obsidian@https://github.com/obsidianmd/obsidian-api/archive/df9434bec6883bd32727f61b1ed1336f7663d0e4.tar.gz:
-    resolution: {tarball: https://github.com/obsidianmd/obsidian-api/archive/df9434bec6883bd32727f61b1ed1336f7663d0e4.tar.gz}
-    version: 1.6.6
+  obsidian@1.13.1:
+    resolution: {integrity: sha512-qtTEA2pmhJzhuhJqzbBFRYhpIOqvW+krDYjtFynv66KbxBbumHBlsJfWw3I4jtnK/6fZwbQhCrmmDdRwXmX56w==}
     peerDependencies:
-      '@codemirror/state': ^6.0.0
-      '@codemirror/view': ^6.0.0
+      '@codemirror/state': 6.5.0
+      '@codemirror/view': 6.38.6
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -1705,7 +1704,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  obsidian@https://github.com/obsidianmd/obsidian-api/archive/df9434bec6883bd32727f61b1ed1336f7663d0e4.tar.gz(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
+  obsidian@1.13.1(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
     dependencies:
       '@codemirror/state': 6.4.0
       '@codemirror/view': 6.23.1

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,9 @@ import {
   Platform,
   Plugin,
   PluginSettingTab,
+  requireApiVersion,
   Setting,
+  type SettingDefinitionItem,
 } from 'obsidian';
 
 export default class TableEditorPlugin extends Plugin {
@@ -372,6 +374,77 @@ class TableEditorSettingsTab extends PluginSettingTab {
     this.plugin = plugin;
   }
 
+  public getSettingDefinitions(): SettingDefinitionItem<
+    keyof TableEditorPluginSettings & string
+  >[] {
+    if (!requireApiVersion('1.13.0')) return [];
+
+    return [
+      {
+        name: 'Bind enter to table navigation',
+        desc:
+          'Requires restart of Obsidian. If enabled, when the cursor is in a table, enter advances to the next ' +
+          'row. Disabling this can help avoid conflicting with tag or CJK ' +
+          'autocompletion. If disabling, bind "Go to ..." in the Obsidian Hotkeys settings.',
+        control: {
+          type: 'toggle',
+          key: 'bindEnter',
+          defaultValue: defaultSettings.bindEnter,
+        },
+      },
+      {
+        name: 'Bind tab to table navigation',
+        desc:
+          'Requires restart of Obsidian. If enabled, when the cursor is in a table, tab/shift+tab navigate ' +
+          'between cells. Disabling this can help avoid conflicting with tag ' +
+          'or CJK autocompletion. If disabling, bind "Go to ..." in the Obsidian Hotkeys settings.',
+        control: {
+          type: 'toggle',
+          key: 'bindTab',
+          defaultValue: defaultSettings.bindTab,
+        },
+      },
+      {
+        name: 'Pad cell width using spaces',
+        desc:
+          'If enabled, table cells will have spaces added to match the width of the ' +
+          'longest cell in the column.',
+        render: (setting) => {
+          setting.addToggle((toggle) =>
+            toggle
+              .setValue(this.plugin.settings.formatType === FormatType.NORMAL)
+              .onChange((value) => {
+                this.plugin.settings.formatType = value
+                  ? FormatType.NORMAL
+                  : FormatType.WEAK;
+                void this.plugin.saveData(this.plugin.settings);
+                this.update();
+              }),
+          );
+        },
+      },
+      {
+        name: 'Show icon in sidebar',
+        desc:
+          'If enabled, a button which opens the table controls toolbar will be added to the Obsidian sidebar. ' +
+          'The toolbar can also be opened with a Hotkey. Changes only take effect on reload.',
+        control: {
+          type: 'toggle',
+          key: 'showRibbonIcon',
+          defaultValue: defaultSettings.showRibbonIcon,
+        },
+      },
+      {
+        name: 'Support Advanced Tables',
+        searchable: false,
+        render: (setting) => {
+          setting.settingEl.empty();
+          renderDonation(setting.settingEl);
+        },
+      },
+    ];
+  }
+
   public display(): void {
     const { containerEl } = this;
     containerEl.empty();
@@ -440,34 +513,38 @@ class TableEditorSettingsTab extends PluginSettingTab {
           }),
       );
 
-    const div = containerEl.createDiv({
-      cls: 'advanced-tables-donation',
-    });
-
-    const donateText = activeDocument.createElement('p');
-    donateText.appendText(
-      'If this plugin adds value for you and you would like to help support ' +
-      'continued development, please use the buttons below:',
-    );
-    div.appendChild(donateText);
-
-    const parser = new DOMParser();
-
-    div.appendChild(
-      createDonateButton(
-        'https://paypal.me/tgrosinger',
-        parser.parseFromString(paypal, 'text/xml').documentElement,
-      ),
-    );
-
-    div.appendChild(
-      createDonateButton(
-        'https://www.buymeacoffee.com/tgrosinger',
-        parser.parseFromString(buyMeACoffee, 'text/xml').documentElement,
-      ),
-    );
+    renderDonation(containerEl);
   }
 }
+
+const renderDonation = (containerEl: HTMLElement): void => {
+  const div = containerEl.createDiv({
+    cls: 'advanced-tables-donation',
+  });
+
+  const donateText = activeDocument.createElement('p');
+  donateText.appendText(
+    'If this plugin adds value for you and you would like to help support ' +
+      'continued development, please use the buttons below:',
+  );
+  div.appendChild(donateText);
+
+  const parser = new DOMParser();
+
+  div.appendChild(
+    createDonateButton(
+      'https://paypal.me/tgrosinger',
+      parser.parseFromString(paypal, 'text/xml').documentElement,
+    ),
+  );
+
+  div.appendChild(
+    createDonateButton(
+      'https://www.buymeacoffee.com/tgrosinger',
+      parser.parseFromString(buyMeACoffee, 'text/xml').documentElement,
+    ),
+  );
+};
 
 const createDonateButton = (link: string, img: HTMLElement): HTMLElement => {
   const a = activeDocument.createElement('a');

--- a/src/main.ts
+++ b/src/main.ts
@@ -413,11 +413,11 @@ class TableEditorSettingsTab extends PluginSettingTab {
           setting.addToggle((toggle) =>
             toggle
               .setValue(this.plugin.settings.formatType === FormatType.NORMAL)
-              .onChange((value) => {
+              .onChange(async (value) => {
                 this.plugin.settings.formatType = value
                   ? FormatType.NORMAL
                   : FormatType.WEAK;
-                void this.plugin.saveData(this.plugin.settings);
+                await this.plugin.saveData(this.plugin.settings);
                 this.update();
               }),
           );


### PR DESCRIPTION
Adds the Obsidian 1.13 declarative settings path while retaining the legacy `display()` fallback, custom-rendered controls, and existing save/update side effects. The Obsidian API dependency is updated for the new interface.

Source checks and production build pass. A real-app visual smoke test remains recommended for the custom settings controls.